### PR TITLE
[codex] Update writing homepage positioning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,9 +8,9 @@ middle_name:
 last_name: Zhang
 email:
 description: > # the ">" symbol means to ignore newlines until "footer_text:"
-  Weijian Zhang's personal website and writing on production AI, model behaviour, AI product design, and decision-making.
+  Weijian Zhang's personal website and writing on open model systems, evaluation loops, agent-ready tools, and decision-making.
 footer_text: >
-keywords: weijian zhang, AI, LLM evaluation, fine-tuning, model behaviour, AI product design, decision-making # add your own keywords or leave empty
+keywords: weijian zhang, AI, open model systems, open-weight models, LLM evaluation, fine-tuning, model behaviour, agent-ready tools, decision-making # add your own keywords or leave empty
 lang: en # the language of your site (for example: en, fr, cn, ru, etc.)
 icon: favicon.ico # the emoji used as the favicon (alternatively, provide image name in /assets/img/)
 
@@ -121,7 +121,7 @@ bing_site_verification: # out your bing-site-verification ID (Bing Webmaster)
 # -----------------------------------------------------------------------------
 
 blog_name: writing # blog_name will be displayed in your blog page
-blog_description: Essays on production AI, model behaviour, AI product design, and decision-making.
+blog_description: Essays on open model systems, agent-ready tools, evaluation loops, and decision-making.
 permalink: /writing/:year/:title/
 
 # Pagination
@@ -183,6 +183,19 @@ latest_posts:
   enabled: true
   scrollable: true # adds a vertical scroll bar if there are more than 3 new posts items
   limit: 6 # leave blank to include all the blog posts
+
+worth_reading:
+  enabled: true
+  posts:
+    - title: Building Software for Agents
+      url: https://notesfromzero.substack.com/p/building-software-for-agents
+      description: "The core frame: software is increasingly operated by agents, so context, tools, specs, and validation become first-class design materials."
+    - title: Auto Research for Classic Machine Learning
+      url: https://notesfromzero.substack.com/p/auto-research-for-classic-machine
+      description: "A small-model example of the bigger point: use bounded, inspectable systems when they solve the problem better than another large model."
+    - title: Paper Fluff Cutter
+      url: https://notesfromzero.substack.com/p/paper-fluff-cutter
+      description: "A practical tool for compressing research into claims, evidence, and useful explanations."
 
 # -----------------------------------------------------------------------------
 # Jekyll settings

--- a/_includes/latest_posts.liquid
+++ b/_includes/latest_posts.liquid
@@ -12,7 +12,7 @@
         {% if site.latest_posts.limit %}
           {% assign latest_posts_limit = site.latest_posts.limit %}
         {% else %}
-          {% assign latest_posts_limit = latest_posts_size %}
+          {% assign latest_posts_limit = 3 %}
         {% endif %}
         {% for item in latest_posts limit: latest_posts_limit %}
           <tr>

--- a/_includes/worth_reading.liquid
+++ b/_includes/worth_reading.liquid
@@ -1,0 +1,17 @@
+<div class="news worth-reading">
+  {% if site.worth_reading.posts != blank %}
+    <div class="table-responsive">
+      <table class="table table-sm table-borderless">
+        {% for item in site.worth_reading.posts limit: 3 %}
+          <tr>
+            <th scope="row" style="width: 20%">0{{ forloop.index }}</th>
+            <td>
+              <a class="news-title" href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}</a>
+              <p>{{ item.description }}</p>
+            </td>
+          </tr>
+        {% endfor %}
+      </table>
+    </div>
+  {% endif %}
+</div>

--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -56,6 +56,14 @@ layout: default
       {% include latest_posts.liquid %}
     {% endif %}
 
+    <!-- Worth reading -->
+    {% if page.worth_reading and site.worth_reading.enabled %}
+      <h2>
+        <a href="{{ '/writing/' | relative_url }}" style="color: inherit">worth reading</a>
+      </h2>
+      {% include worth_reading.liquid %}
+    {% endif %}
+
     <!-- Selected papers -->
     {% if page.selected_papers %}
       <h2>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -2,22 +2,25 @@
 layout: about
 title: home
 permalink: /
-subtitle: Building AI systems and evaluation loops for understanding and steering model behaviour
+subtitle: Building open model systems you can inspect, steer, and improve
 
 profile: false
 
 news: false # includes a list of news items
 latest_posts: true # includes a list of the newest posts
+worth_reading: true # includes a curated starting list for new readers
 selected_papers: false # includes a list of papers marked as "selected={true}"
 social: true # includes social icons at the bottom of the page
 ---
 
-Currently building Tuned Tensor and small tools for understanding model behaviour. I write about production AI, AI product design, and decision-making under real-world constraints - for builders, technical leaders, and curious operators who care about substance over hype.
+I build open model systems: tools and evaluation loops that make model behaviour inspectable, steerable, and useful in real workflows.
+
+Currently building Tuned Tensor and small tools for understanding model behaviour. I write about open models, agent-ready software, evaluation, and decision-making under real-world constraints - for builders, technical leaders, and curious operators who care about substance over hype.
 
 [Work](/building/) · [Writing](/writing/) · [Subscribe](https://notesfromzero.substack.com)
 
 ---
 
-My work sits at the intersection of production LLM systems, model evaluation and fine-tuning, AI product design, and the mental models needed to think clearly in fast-moving technical environments.
+My work sits at the intersection of production LLM systems, open-weight model evaluation and fine-tuning, agent-ready tools, and the mental models needed to think clearly in fast-moving technical environments.
 
 This site is where I collect what I’m learning, building, and testing in public.


### PR DESCRIPTION
## Summary
- Reframe the site and writing page around open model systems, agent-ready tools, evaluation loops, and decision-making.
- Keep the homepage latest-post list capped to three posts by default.
- Add a configurable homepage worth-reading section with three curated article links.

## Validation
- `ruby -ryaml -e 'YAML.load_file("_config.yml"); front = File.read("_pages/about.md").split(/^---\\s*$/, 3)[1]; YAML.safe_load(front); puts "yaml ok"'
- `npx prettier --check _config.yml _includes/latest_posts.liquid _includes/worth_reading.liquid _layouts/about.liquid _pages/about.md`
- `git diff --check`

## Notes
- Full `bundle exec jekyll build` could not be run locally because the current shell has Ruby 2.6.10 and the bundle requires Ruby >= 3.0.
